### PR TITLE
fix(crossref): deep-review follow-ups (enumeration parity, JADE chunk_text, OTHER_CODE parents, pipeline_version, cleaner guards)

### DIFF
--- a/CROSSREFERENCE.md
+++ b/CROSSREFERENCE.md
@@ -1118,18 +1118,23 @@ Why:
 ### 10.6 Step F: ambiguity resolver
 
 Step F is reachable from Step A, Step B, and Step C whenever the SQL returns
-more than one row. It must apply the following ranked preferences:
+more than one row. The implemented rules are:
 
-1. if `detected_family` is set, prefer rows whose `code_family` equals it;
-   if exactly one row remains, accept;
-2. if no family was detected, prefer the best family tier present, in order:
-   `CGI` > `LPF` > `CIBS` > `OTHER_CODE` > `NULL`. Accept only if exactly
-   one row sits at the chosen tier;
-3. prefer exact normalized-number hit over loose or fuzzy;
-4. prefer candidate with highest semantic score if semantic fallback ran;
-5. if a tie remains at the chosen tier, reject rather than guess.
+1. if `detected_family` is set, narrow the candidate list to rows whose
+   `code_family` equals it; if exactly one remains, accept;
+2. if `detected_family` is not set, pick the best family tier present, in
+   order `CGI` > `LPF` > `CIBS` > `OTHER_CODE` > `NULL`. Accept only if
+   exactly one row sits at the chosen tier;
+3. otherwise reject.
 
-Precision first. Implementation: `crossreference.resolver._resolve_ambiguity`.
+The "exact over loose" and "highest semantic score" preferences listed in
+earlier drafts are enforced **upstream**, not inside the tie-break: Step A
+runs before Step B (so an exact hit wins over a loose hit by construction);
+the semantic resolver applies its own threshold and `LIMIT 1` on best
+cosine similarity before returning. The tie-break only sees the rows the
+upstream layers were unable to disambiguate by family scope.
+
+Implementation: :func:`crossreference.resolver._resolve_ambiguity`.
 
 ---
 
@@ -1137,7 +1142,8 @@ Precision first. Implementation: `crossreference.resolver._resolve_ambiguity`.
 
 Confidence is not just a numeric similarity score. It must encode why the link is trustworthy.
 
-Suggested scoring:
+Reference implementation: :func:`crossreference.confidence.score_confidence`.
+Calibrated values currently in use:
 
 ```python
 confidence = 0.0
@@ -1148,43 +1154,60 @@ elif resolver_method == "exact_number_and_temporal_unique":
     confidence = 0.96
 elif resolver_method == "exact_loose_and_explicit_code":
     confidence = 0.92
+elif resolver_method == "exact_loose":
+    confidence = 0.85
 elif resolver_method == "exact_number_core_family_only":
     confidence = 0.84
 elif resolver_method == "fuzzy_scoped":
-    confidence = 0.74
+    confidence = 0.78
 elif resolver_method == "semantic_scoped":
-    confidence = 0.62
+    confidence = 0.65
 ```
 
 Adjustments:
 
 ```python
 if source_type == "jade" and mention_in_vu_like_section:
-    confidence += 0.03
+    confidence += 0.05
 
 if repeated_in_multiple_chunks:
-    confidence += 0.03
+    confidence += 0.05
+
+# Tiered semantic boost on top of the semantic_scoped base when the
+# resolver_method is "semantic_scoped":
+if resolver_method == "semantic_scoped" and semantic_similarity is not None:
+    if semantic_similarity >= 0.92: confidence += 0.35
+    elif semantic_similarity >= 0.88: confidence += 0.30
+    elif semantic_similarity >= 0.84: confidence += 0.25
+    elif semantic_similarity >= 0.80: confidence += 0.20
+    elif semantic_similarity >= 0.75: confidence += 0.15
 
 if no_explicit_code_alias:
-    confidence -= 0.10
+    confidence -= 0.05
 
 if generic_numeric_ref:
-    confidence -= 0.15
-
-if ambiguous_before_tie_break:
-    confidence -= 0.12
+    confidence -= 0.10
 
 confidence = max(0.0, min(1.0, confidence))
 ```
 
-Acceptance rule:
+Acceptance rule (in :func:`crossreference.pipeline._process_source_document`):
 
 ```python
-is_accepted = confidence >= 0.70
+is_accepted = confidence >= 0.55
 ```
 
-Stronger rule:
-- if `resolver_method` is semantic-only and there is no code alias, require `confidence >= 0.80` or reject
+The threshold is deliberately lower than 0.70 to admit fuzzy-scoped (base
+0.78) and semantic-scoped (base 0.65 + tiered boost) hits when they survive
+the resolver's precision-first guards. The base scores and adjustment
+weights compensate, and the no-alias / generic-number penalties stack to
+push genuinely low-signal mentions below the threshold.
+
+Stronger semantic rule (enforced inside the semantic resolver itself, not
+in the confidence layer):
+
+- if a code alias was detected, require cosine similarity ≥ 0.75
+- otherwise require cosine similarity ≥ 0.85
 
 ---
 
@@ -1192,7 +1215,14 @@ Stronger rule:
 
 ### 12.1 Mention identity
 
-Deduplicate mentions with a stable hash such as:
+`mention_hash` identifies a **source mention span**, not the resolution
+outcome. It MUST NOT include `target_legi_doc_id`: re-running the resolver
+(after a normalizer or alias-detector change) must update the existing
+mention row in place rather than creating a new one. Including the target
+in the hash would defeat that and accumulate duplicate mentions.
+
+Reference implementation:
+:func:`crossreference.pipeline._compute_mention_hash`.
 
 ```python
 mention_hash = sha1(
@@ -1203,10 +1233,14 @@ mention_hash = sha1(
         str(match_start),
         str(match_end),
         matched_text,
-        target_legi_doc_id or "",
     ]).encode("utf-8")
 ).hexdigest()
 ```
+
+Note: with this hash and the JADE chunk-text fix (§6.1), the same mention
+can only appear once per `(source_doc_id, source_chunk_id, span)`. The
+per-doc rebuild path always deletes mentions before reinsertion, so
+collisions are exercised only by the graph-retry branch (§14).
 
 ### 12.2 Aggregate accepted mentions into edges
 
@@ -1470,6 +1504,13 @@ Optional extended resolver:
 12. Mention `normalized_number` is computed from the extractor's clean
     `article_token`, never from the rich `matched_text`. The catalog and
     mention keys must converge on the bare article number.
+13. Skip-on-incremental requires **all three** of `source_hash`,
+    `catalog_hash`, and `pipeline_version` to match. Bumping
+    `crossreference._version.PIPELINE_VERSION` forces every source doc to
+    be reprocessed on the next run, even when source content and catalog
+    content are unchanged. This is mandatory whenever inference logic
+    changes (extractor, normalizer, resolver cascade, alias detector,
+    confidence scorer, pipeline orchestrator).
 
 ---
 

--- a/crossreference/__init__.py
+++ b/crossreference/__init__.py
@@ -1,6 +1,20 @@
+from ._version import PIPELINE_VERSION
 from .extractor import extract_article_mentions
 from .normalizer import loose_normalized_number, normalize_article_number
 from .alias_detector import CODE_FAMILY_MAP, infer_code_family
 from .resolver import resolve_article
 from .pipeline import infer_crossreferences
 from .confidence import score_confidence
+
+__all__ = [
+    "CODE_FAMILY_MAP",
+    "PIPELINE_VERSION",
+    "extract_article_mentions",
+    "infer_code_family",
+    "infer_crossreferences",
+    "loose_normalized_number",
+    "normalize_article_number",
+    "resolve_article",
+    "score_confidence",
+]
+

--- a/crossreference/_version.py
+++ b/crossreference/_version.py
@@ -1,0 +1,19 @@
+"""Version stamp for the cross-reference inference pipeline.
+
+Bump :data:`PIPELINE_VERSION` whenever a change to the extractor, normalizer,
+resolver cascade, fuzzy resolver, semantic resolver, alias detector,
+confidence scorer, or pipeline orchestrator would alter the inference output
+for an unchanged source document AND an unchanged catalog snapshot.
+
+The value is persisted alongside ``source_hash`` and ``catalog_hash`` in
+``cross_reference_source_state``; a mismatch forces the document to be
+re-processed even when its content has not changed. Without this, a deploy
+that rewrites e.g. the resolver would silently leave previously-resolved
+documents on the old logic until their LEGI/JADE/BOFIP source data
+changed.
+
+Format is free-form (a date stamp + counter is conventional). Only equality
+matters; there is no ordering semantics.
+"""
+
+PIPELINE_VERSION = "2026.04.30-1"

--- a/crossreference/alias_detector.py
+++ b/crossreference/alias_detector.py
@@ -187,30 +187,39 @@ def get_family_aliases(family: str) -> list[str]:
     return list(info["aliases"])
 
 
-def extract_code_family_from_mention(mention_text: str) -> str | None:
-    """Extract code family from mention text.
-    
-    E.g. "1745 du code général des impôts" -> "CGI"
-         "L. 247 du livre des procédures fiscales" -> "LPF"
-    
+def extract_code_family_from_mention(mention_text: str):
+    """Extract code family + parent_text_ids from a mention's matched_text.
+
+    Mirrors :func:`infer_code_family` but operates on the (typically shorter)
+    matched_text rather than the surrounding context window. Returns the
+    parent_text_ids alongside the family so the resolver can scope catalog
+    queries to a concrete LEGITEXT family even for non-core (OTHER_CODE)
+    mentions — without this, an OTHER_CODE detection produced an empty
+    parent list and downstream fuzzy / semantic fallbacks reverted to the
+    tax-core scope (CGI/LPF/CIBS), which is wrong for non-core citations.
+
+    E.g.:
+        "1745 du code général des impôts"     -> ("CGI",        [...CGI parents...])
+        "L. 247 du livre des procédures fiscales" -> ("LPF",     ["LEGITEXT...006069583"])
+        "L. 1242-1 du code du travail"        -> ("OTHER_CODE", [<code du travail parent ids>])
+        "no match"                            -> (None, [])
+
     Returns:
-        family name (e.g. "CGI", "LPF") or None if not detected.
+        (family_name, list_of_parent_text_ids).
     """
     if not mention_text:
-        return None
-    
+        return None, []
+
     normalized = _normalize_for_alias(mention_text)
-    
-    # Try core aliases first (longest first for specificity)
+
     for norm_alias in _SORTED_CORE_ALIASES:
         if _alias_in_text(norm_alias, normalized):
-            family, _, _ = _ALIAS_TO_FAMILY[norm_alias]
-            return family
-    
-    # Try extended aliases
+            family, _, parent_ids = _ALIAS_TO_FAMILY[norm_alias]
+            return family, list(parent_ids)
+
     extended_aliases = _get_extended_aliases()
     for alias in sorted(extended_aliases.keys(), key=len, reverse=True):
         if _alias_in_text(alias, normalized):
-            return "OTHER_CODE"
-    
-    return None
+            return "OTHER_CODE", list(extended_aliases[alias])
+
+    return None, []

--- a/crossreference/extractor.py
+++ b/crossreference/extractor.py
@@ -46,11 +46,15 @@ _CODE_BOUNDARY_RE = re.compile(
     re.IGNORECASE | re.VERBOSE,
 )
 
-# Extended preposition: du | des | de la | de l' | de l | au | aux | de.
-# Placed first in the extractor so "de l'annexe II" is fully consumed as the
-# preposition rather than leaving a stray "l" attached to the article portion.
-_PREPOSITION_LOOKAHEAD_RE = re.compile(
-    r"^(.+?)\s+(?:du|des|de\s+la|de\s+l['’]|de\s+l\s+|au|aux|de)\s+",
+# Extended preposition matched immediately after the article token. We do NOT
+# allow `.+?` between the token and the preposition: that earlier shape made
+# the first article in an enumeration like "articles 38, 39 et 39 A du CGI"
+# greedily swallow the rest of the enumeration as `article_part`. Anchoring
+# the preposition right at the token boundary means the code-name tail is
+# attached only to the article that genuinely owns it (the last item in the
+# enumeration here).
+_IMMEDIATE_PREPOSITION_RE = re.compile(
+    r"^\s+(?:du|des|de\s+la|de\s+l['’]|de\s+l\s+|au|aux|de)\s+",
     re.IGNORECASE,
 )
 
@@ -112,16 +116,19 @@ def extract_article_mentions(text: str):
                 token_clean = token_clean[: tail_match.start()].rstrip()
             article_token = token_clean
 
-            # Extend matched_text with "du/de/de la/de l'/au/aux <code-name>" if present.
+            # Extend matched_text with "du/de/de la/de l'/au/aux <code-name>" if
+            # the preposition appears IMMEDIATELY after the article token. This
+            # keeps the code clause on the article that actually owns it: in
+            # "articles 38, 39 et 39 A du CGI" only "39 A" gets the tail.
             # article_token is preserved unchanged; only matched_text grows.
+            article_part = matched_raw
             lookahead_end = min(len(text), raw_end + 200)
-            lookahead = text[raw_start:lookahead_end]
+            tail_text = text[raw_end:lookahead_end]
 
-            prepos_match = _PREPOSITION_LOOKAHEAD_RE.match(lookahead)
+            prepos_match = _IMMEDIATE_PREPOSITION_RE.match(tail_text)
             if prepos_match:
-                article_part = prepos_match.group(1).strip()
                 code_start = prepos_match.end()
-                code_text = lookahead[code_start:]
+                code_text = tail_text[code_start:]
 
                 code_boundary_match = _CODE_BOUNDARY_RE.search(remove_accents(code_text))
                 if code_boundary_match:

--- a/crossreference/pipeline.py
+++ b/crossreference/pipeline.py
@@ -376,7 +376,8 @@ def _process_source_document(
     mentions = []
     for raw in raw_mentions:
         result = resolve_article(
-            raw_article_text=raw["matched_text"],
+            article_token=raw["article_token"],
+            matched_text=raw["matched_text"],
             source_date=source_date,
             context_text=raw["context_window"],
             source_type=source_type,

--- a/crossreference/pipeline.py
+++ b/crossreference/pipeline.py
@@ -25,6 +25,7 @@ from database.cross_reference_manage import (
     refresh_legi_reference_catalog,
     upsert_source_state_hash,
 )
+from crossreference._version import PIPELINE_VERSION
 from database.graph_manage import init_graph_schema, inject_cross_reference_edges
 from crossreference.alias_detector import invalidate_extended_alias_cache
 from crossreference.extractor import extract_article_mentions
@@ -95,13 +96,18 @@ def infer_crossreferences(
             doc_started = time.perf_counter()
 
             try:
-                # Check incremental: skip if hash unchanged
+                # Check incremental: skip when source content, catalog content,
+                # AND inference pipeline version are all unchanged. Bumping
+                # PIPELINE_VERSION on any extractor/resolver/normalizer change
+                # invalidates every stored state row at deploy time, forcing a
+                # full reprocess even when LEGI and JADE/BOFIP have not moved.
                 current_hash = doc_info["source_hash"]
                 stored_state = _get_stored_state(src, doc_info["doc_id"])
                 hashes_match = (
                     stored_state
                     and stored_state["source_hash"] == current_hash
                     and stored_state["catalog_hash"] == catalog_hash
+                    and stored_state.get("pipeline_version") == PIPELINE_VERSION
                 )
                 if hashes_match and stored_state.get("graph_sync_ok"):
                     logger.debug(f"Skipping {src} doc {doc_info['doc_id']}: hash unchanged")
@@ -221,6 +227,7 @@ def _upsert_source_state(
             source_hash,
             catalog_hash=catalog_hash,
             graph_sync_ok=graph_sync_ok,
+            pipeline_version=PIPELINE_VERSION,
         )
         conn.commit()
 

--- a/crossreference/pipeline.py
+++ b/crossreference/pipeline.py
@@ -290,6 +290,18 @@ def _aggregate_bofip_documents() -> list[dict]:
 
 
 def _get_source_chunks(source_type: str, doc_id: str) -> list[dict]:
+    """Fetch chunk-level rows for a source document.
+
+    extraction_text is the field the regex extractor reads. Per
+    CROSSREFERENCE.md §6.1 / §6.2:
+    - JADE stores the full body in ``text`` and duplicates it per chunk row,
+      so we MUST use ``chunk_text`` (per-chunk, title + chunk slice) for
+      regex extraction. Otherwise every JADE mention is duplicated across
+      every chunk of the decision and the resulting offsets are
+      document-global instead of chunk-local.
+    - BOFIP stores per-chunk raw content in ``text``; ``chunk_text`` is the
+      enriched embedding form. We keep ``text`` for extraction.
+    """
     with get_connection() as conn:
         cursor = conn.cursor()
         if source_type == "jade":
@@ -302,16 +314,25 @@ def _get_source_chunks(source_type: str, doc_id: str) -> list[dict]:
                 """,
                 (doc_id,),
             )
-        else:
-            cursor.execute(
-                """
-                SELECT chunk_id, chunk_index, text, chunk_text
-                FROM bofip
-                WHERE doc_id = %s
-                ORDER BY chunk_index
-                """,
-                (doc_id,),
-            )
+            return [
+                {
+                    "chunk_id": row[0],
+                    "chunk_index": row[1],
+                    "extraction_text": row[3] or "",
+                    "chunk_text": row[3] or "",
+                }
+                for row in cursor.fetchall()
+            ]
+
+        cursor.execute(
+            """
+            SELECT chunk_id, chunk_index, text, chunk_text
+            FROM bofip
+            WHERE doc_id = %s
+            ORDER BY chunk_index
+            """,
+            (doc_id,),
+        )
         return [
             {
                 "chunk_id": row[0],

--- a/crossreference/resolver.py
+++ b/crossreference/resolver.py
@@ -27,38 +27,52 @@ _FAMILY_PREFERENCE = {"CGI": 0, "LPF": 1, "CIBS": 2, "OTHER_CODE": 3}
 
 
 def resolve_article(
-    raw_article_text: str,
+    article_token: str,
     source_date: date,
     context_text: str = "",
     source_type: str = "",
     model: str = EMBEDDING_MODEL,
+    matched_text: str | None = None,
 ) -> dict:
     """Resolve one article mention to a versioned legi.doc_id.
+
+    Args:
+        article_token: clean article span (number + letter prefix + suffix).
+            This is the canonical key for catalog lookup; it must match what
+            the pipeline stores in mention.normalized_number.
+        source_date: temporal filter for the catalog.
+        context_text: ~200-char context window for alias detection / semantic
+            fallback.
+        source_type: 'jade' or 'bofip'.
+        model: embedding model used for semantic fallback.
+        matched_text: rich span (article_token + optional trailing code-name
+            clause). Used only for `extract_code_family_from_mention` so the
+            normalisation key stays bound to article_token.
 
     Returns dict with:
         target_legi_doc_id, target_parent_text_id, target_article_number,
         target_start_date, target_end_date,
         resolver_method, confidence, explain
     """
-    normalized = normalize_article_number(raw_article_text)
+    if matched_text is None:
+        matched_text = article_token
+
+    normalized = normalize_article_number(article_token)
     loose = loose_normalized_number(normalized)
 
-    # Detect code family from context
     detected_family, detected_alias, detected_parents = infer_code_family(context_text)
-    
-    # If not detected from context, try extracting from mention itself
-    mention_family = None
+
     if not detected_family:
-        mention_family = extract_code_family_from_mention(raw_article_text)
+        mention_family = extract_code_family_from_mention(matched_text)
         if mention_family:
-            # Use extracted family to get parent_text_ids
             from crossreference.alias_detector import CODE_FAMILY_MAP
             fam_info = CODE_FAMILY_MAP.get(mention_family, {})
             detected_parents = fam_info.get("parent_text_ids", [])
             detected_family = mention_family
 
     explain = {
-        "raw_text": raw_article_text,
+        "raw_text": matched_text,
+        "article_token": article_token,
         "normalized": normalized,
         "loose": loose,
         "detected_code_alias": detected_alias,

--- a/crossreference/resolver.py
+++ b/crossreference/resolver.py
@@ -62,13 +62,15 @@ def resolve_article(
 
     detected_family, detected_alias, detected_parents = infer_code_family(context_text)
 
+    # If context-based detection did not fire, fall back to the matched_text
+    # itself. extract_code_family_from_mention now returns parent_text_ids
+    # for OTHER_CODE families too, so fuzzy / semantic fallbacks scope to the
+    # correct legal corpus instead of reverting to tax core.
     if not detected_family:
-        mention_family = extract_code_family_from_mention(matched_text)
+        mention_family, mention_parents = extract_code_family_from_mention(matched_text)
         if mention_family:
-            from crossreference.alias_detector import CODE_FAMILY_MAP
-            fam_info = CODE_FAMILY_MAP.get(mention_family, {})
-            detected_parents = fam_info.get("parent_text_ids", [])
             detected_family = mention_family
+            detected_parents = mention_parents
 
     explain = {
         "raw_text": matched_text,

--- a/database/cross_reference_manage.py
+++ b/database/cross_reference_manage.py
@@ -102,6 +102,12 @@ def _ensure_source_state_columns(cursor):
         ADD COLUMN IF NOT EXISTS graph_sync_ok BOOLEAN NOT NULL DEFAULT false
         """
     )
+    cursor.execute(
+        """
+        ALTER TABLE cross_reference_source_state
+        ADD COLUMN IF NOT EXISTS pipeline_version TEXT NOT NULL DEFAULT ''
+        """
+    )
     _SOURCE_STATE_COLUMNS_ENSURED = True
 
 
@@ -229,6 +235,7 @@ def create_cross_reference_tables():
                 source_doc_id TEXT NOT NULL,
                 source_hash TEXT NOT NULL,
                 catalog_hash TEXT NOT NULL DEFAULT '',
+                pipeline_version TEXT NOT NULL DEFAULT '',
                 graph_sync_ok BOOLEAN NOT NULL DEFAULT false,
                 updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
                 PRIMARY KEY (source_type, source_doc_id)
@@ -244,6 +251,12 @@ def create_cross_reference_tables():
             """
             ALTER TABLE cross_reference_source_state
             ADD COLUMN IF NOT EXISTS graph_sync_ok BOOLEAN NOT NULL DEFAULT false
+            """
+        )
+        cursor.execute(
+            """
+            ALTER TABLE cross_reference_source_state
+            ADD COLUMN IF NOT EXISTS pipeline_version TEXT NOT NULL DEFAULT ''
             """
         )
         cursor.execute("""
@@ -495,7 +508,7 @@ def get_source_state(cursor, source_type, source_doc_id):
     _ensure_source_state_columns(cursor)
     cursor.execute(
         """
-        SELECT source_hash, catalog_hash, graph_sync_ok
+        SELECT source_hash, catalog_hash, graph_sync_ok, pipeline_version
         FROM cross_reference_source_state
         WHERE source_type = %s AND source_doc_id = %s
         """,
@@ -508,6 +521,7 @@ def get_source_state(cursor, source_type, source_doc_id):
         "source_hash": row[0],
         "catalog_hash": row[1] or "",
         "graph_sync_ok": bool(row[2]),
+        "pipeline_version": row[3] or "",
     }
 
 
@@ -526,21 +540,31 @@ def upsert_source_state_hash(
     source_hash,
     catalog_hash="",
     graph_sync_ok=False,
+    pipeline_version="",
 ):
     """Upsert source hash after a successful per-document rebuild."""
     _ensure_source_state_columns(cursor)
     cursor.execute(
         """
         INSERT INTO cross_reference_source_state (
-            source_type, source_doc_id, source_hash, catalog_hash, graph_sync_ok, updated_at
-        ) VALUES (%s, %s, %s, %s, %s, NOW())
+            source_type, source_doc_id, source_hash, catalog_hash,
+            pipeline_version, graph_sync_ok, updated_at
+        ) VALUES (%s, %s, %s, %s, %s, %s, NOW())
         ON CONFLICT (source_type, source_doc_id) DO UPDATE SET
             source_hash = EXCLUDED.source_hash,
             catalog_hash = EXCLUDED.catalog_hash,
+            pipeline_version = EXCLUDED.pipeline_version,
             graph_sync_ok = EXCLUDED.graph_sync_ok,
             updated_at = NOW()
         """,
-        (source_type, source_doc_id, source_hash, catalog_hash, graph_sync_ok),
+        (
+            source_type,
+            source_doc_id,
+            source_hash,
+            catalog_hash,
+            pipeline_version,
+            graph_sync_ok,
+        ),
     )
 
 

--- a/database/cross_reference_manage.py
+++ b/database/cross_reference_manage.py
@@ -757,30 +757,47 @@ def _get_admin_connection():
     )
 
 
-def clean_cross_reference_data(source: str = "all"):
+def clean_cross_reference_data(source: str = "all", reset_catalog: bool = False):
     """Clean cross-reference tables for one or all sources to force reprocessing.
-    
+
     Removes:
     - cross_reference_legi_mentions for source
     - cross_reference_legi_edges for source
     - cross_reference_source_state for source
-    
+
+    When ``reset_catalog`` is true and ``source == 'all'``, also truncates
+    ``legi_reference_catalog`` so the next ``infer_crossreferences`` run
+    rebuilds it from scratch. The catalog is content-addressed by
+    ``catalog_hash``, so a rebuild from identical LEGI data produces the
+    same hash; this option is useful only when the catalog content itself
+    is suspected to be corrupt.
+
     Args:
         source: 'jade', 'bofip', or 'all'
+        reset_catalog: also TRUNCATE legi_reference_catalog (only valid
+            when source == 'all').
     """
     if source not in ("jade", "bofip", "all"):
         raise ValueError(f"Invalid source: {source}. Use jade, bofip, or all.")
-    
+    if reset_catalog and source != "all":
+        raise ValueError(
+            "reset_catalog=True is only valid when source='all'; pass --all "
+            "or omit reset_catalog."
+        )
+
     conn = None
     try:
         conn = _get_admin_connection()
         cursor = conn.cursor()
-        
+
         if source == "all":
             logger.info("Cleaning ALL cross-reference data (jade and bofip)")
             cursor.execute("DELETE FROM cross_reference_legi_mentions")
             cursor.execute("DELETE FROM cross_reference_legi_edges")
             cursor.execute("DELETE FROM cross_reference_source_state")
+            if reset_catalog:
+                logger.info("Truncating legi_reference_catalog")
+                cursor.execute("TRUNCATE TABLE legi_reference_catalog")
         else:
             logger.info(f"Cleaning cross-reference data for source={source}")
             cursor.execute(
@@ -795,22 +812,24 @@ def clean_cross_reference_data(source: str = "all"):
                 "DELETE FROM cross_reference_source_state WHERE source_type = %s",
                 (source,)
             )
-        
+
         conn.commit()
-        
-        # Log results
+
         cursor.execute("SELECT COUNT(*) FROM cross_reference_legi_mentions")
         mentions_count = cursor.fetchone()[0]
         cursor.execute("SELECT COUNT(*) FROM cross_reference_legi_edges")
         edges_count = cursor.fetchone()[0]
         cursor.execute("SELECT COUNT(*) FROM cross_reference_source_state")
         state_count = cursor.fetchone()[0]
-        
+        cursor.execute("SELECT COUNT(*) FROM legi_reference_catalog")
+        catalog_count = cursor.fetchone()[0]
+
         logger.info(
             f"Clean complete: {mentions_count} mentions remaining, "
-            f"{edges_count} edges remaining, {state_count} state entries remaining"
+            f"{edges_count} edges remaining, {state_count} state entries remaining, "
+            f"{catalog_count} catalog rows remaining"
         )
-        
+
     except Exception as e:
         logger.error(f"Error cleaning cross-reference data: {e}")
         if conn:

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ Usage:
     main.py export_table (--table=<name>) [--output=<path>] [--split] [--debug]
     main.py upload_dataset (--all | --dataset-name=<name>) [--input=<path>] [--repository=<name>] [--private] [--debug]
     main.py infer_crossreferences (--source=<source>) [--model=<model_name>] [--debug]
-    main.py clean_crossreferences (--source=<source>) [--debug]
+    main.py clean_crossreferences (--source=<source>) [--reset-catalog] [--yes] [--debug]
     main.py -h | --help
 
 Commands:
@@ -38,6 +38,8 @@ Options:
     --output=<path>         Output folder for Parquet files
     --split                 Split the table into smaller tables before exporting
     --private               Upload dataset as private on Hugging Face
+    --reset-catalog         Also TRUNCATE legi_reference_catalog (only valid with --source=all)
+    --yes                   Skip the interactive confirmation prompt for destructive operations
     --debug                 Enable debug logging
     -h --help               Show this help message
 
@@ -276,12 +278,44 @@ def main():
             from database.cross_reference_manage import clean_cross_reference_data
 
             source = args["--source"]
+            reset_catalog = bool(args.get("--reset-catalog"))
+            assume_yes = bool(args.get("--yes"))
             if source not in ("jade", "bofip", "all"):
                 logger.error(f"Invalid source for clean_crossreferences: {source}. Use jade, bofip, or all.")
                 return 1
+            if reset_catalog and source != "all":
+                logger.error(
+                    "--reset-catalog is only valid with --source=all"
+                )
+                return 1
 
-            logger.info(f"Cleaning cross-reference data for source={source}")
-            clean_cross_reference_data(source=source)
+            scope_label = "ALL JADE+BOFIP" if source == "all" else source.upper()
+            extras = " AND legi_reference_catalog" if reset_catalog else ""
+            warning = (
+                f"clean_crossreferences will DELETE mentions, edges, and source-state for "
+                f"{scope_label}{extras}. This is irreversible."
+            )
+            logger.warning(warning)
+            if not assume_yes:
+                if not sys.stdin.isatty():
+                    logger.error(
+                        "Refusing to proceed without --yes when stdin is not a TTY. "
+                        "Re-run with --yes to confirm."
+                    )
+                    return 1
+                try:
+                    response = input("Type 'yes' to confirm: ").strip().lower()
+                except EOFError:
+                    response = ""
+                if response != "yes":
+                    logger.info("Aborted by user.")
+                    return 1
+
+            logger.info(
+                f"Cleaning cross-reference data for source={source} "
+                f"(reset_catalog={reset_catalog})"
+            )
+            clean_cross_reference_data(source=source, reset_catalog=reset_catalog)
             logger.info(f"Successfully cleaned cross-reference data for {source}")
 
         return 0

--- a/tests/crossreference/test_alias_detector.py
+++ b/tests/crossreference/test_alias_detector.py
@@ -29,10 +29,62 @@ def test_infer_code_family_core_lpf():
 
 
 def test_extract_code_family_from_mention_core():
-    assert extract_code_family_from_mention("1745 du code général des impôts") == "CGI"
-    assert extract_code_family_from_mention(
+    family, parents = extract_code_family_from_mention(
+        "1745 du code général des impôts"
+    )
+    assert family == "CGI"
+    assert "LEGITEXT000006069577" in parents
+
+    family, parents = extract_code_family_from_mention(
         "L. 247 du livre des procédures fiscales"
-    ) == "LPF"
+    )
+    assert family == "LPF"
+    assert parents == ["LEGITEXT000006069583"]
+
+
+def test_extract_code_family_from_mention_unknown_returns_none():
+    family, parents = extract_code_family_from_mention("article unrelated text")
+    assert family is None
+    assert parents == []
+
+
+def test_extract_code_family_from_mention_other_code_returns_parents(monkeypatch):
+    """A5 regression: when a non-core code is detected from matched_text,
+    parent_text_ids must accompany the OTHER_CODE family so the resolver's
+    fuzzy / semantic scopes do not silently revert to tax core."""
+    invalidate_extended_alias_cache()
+
+    class _FakeCursor:
+        def execute(self, sql):
+            self._rows = [
+                ("LEGITEXT000006072050", "code du travail"),
+            ]
+
+        def fetchall(self):
+            return self._rows
+
+    class _FakeConn:
+        def cursor(self):
+            return _FakeCursor()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+    monkeypatch.setattr(
+        "database.database_manage.get_connection",
+        lambda: _FakeConn(),
+    )
+
+    family, parents = extract_code_family_from_mention(
+        "L. 1242-1 du code du travail"
+    )
+    assert family == "OTHER_CODE"
+    assert parents == ["LEGITEXT000006072050"]
+
+    invalidate_extended_alias_cache()
 
 
 def test_infer_code_family_unknown_returns_none():

--- a/tests/crossreference/test_extractor.py
+++ b/tests/crossreference/test_extractor.py
@@ -69,6 +69,24 @@ def test_enumeration_yields_one_mention_per_token():
     assert normalized == ["38", "39", "39 A"]
 
 
+def test_enumeration_attaches_code_tail_only_to_owning_token():
+    """A1+A2 regression: in 'articles 38, 39 et 39 A du CGI' the trailing
+    'du CGI' belongs to '39 A' alone. Earlier extractor builds polluted the
+    matched_text of every preceding item with the rest of the enumeration."""
+    mentions = _mentions("les articles 38, 39 et 39 A du code général des impôts")
+    matched_texts = [m for (m, *_rest) in mentions]
+    assert matched_texts[0] == "38"
+    assert matched_texts[1] == "39"
+    assert matched_texts[2] == "39 A du code général des impôts"
+    # Both pipeline.normalize_article_number(article_token) and
+    # resolver-side normalize_article_number(matched_text) must collapse to
+    # the same key for every item.
+    for matched, token in [(m, t) for (m, t, *_rest) in mentions]:
+        assert normalize_article_number(matched) == normalize_article_number(token), (
+            f"key divergence on enumeration item {token!r} / {matched!r}"
+        )
+
+
 def test_code_du_travail_non_core():
     mentions = _mentions("Aux termes de l article L. 1242-1 du code du travail")
     assert len(mentions) == 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #42. A read-only multi-agent review of the merged implementation surfaced five concrete failure modes that would still bite real data. This PR fixes all five, in independently reviewable commits, with regression tests for each.

## Commits

| Commit | Review finding | What it removes |
| --- | --- | --- |
| `fix(crossref): bound extractor lookahead and pass article_token to resolver` | A1 + A2 | The extractor's preposition lookahead used `^(.+?)\s+(?:du|…)\s+` over a 200-char window starting at `raw_start`, so for `articles 38, 39 et 39 A du CGI` the leftmost ` du ` (which actually belongs to `39 A`) attached to the **first** item. Separately, `resolve_article` re-normalised from `matched_text` while the pipeline normalised from `article_token` — for any input where the trailing-clause stripper could not collapse `matched_text` back to the token (notably enumerations after the bug above), the stored `normalized_number` disagreed with the key the resolver actually queried, leaving the mention silently `unresolved` while the table looked correct. The lookahead now requires the preposition immediately after the token; `resolve_article` takes both `article_token` (key) and `matched_text` (alias hint). |
| `fix(crossref): JADE extraction reads chunk_text instead of duplicated text` | A3 + A4 | For JADE, `legi.text` / `jade.text` is the **full document body** repeated on every chunk row (`download_and_processing/files_processing.py:530`). Running the regex extractor on that field produced N copies of every mention with N different `mention_hash` values, inflated `aggregate_and_upsert_edges`'s `occurrence_count` N-fold, and structurally fired the `repeated_in_chunks` confidence boost on every JADE mention. `_get_source_chunks` now serves `chunk_text` (per-chunk title + slice) for JADE per CROSSREFERENCE.md §6.1. BOFIP keeps `text` (per-chunk per §6.2). |
| `fix(crossref): OTHER_CODE mention path carries parent_text_ids` | A5 | `extract_code_family_from_mention` returned only the family name. The resolver looked up `CODE_FAMILY_MAP` for `parent_text_ids`, but that map has no `OTHER_CODE` entry, so any non-core code recognised from `matched_text` ended up with `detected_parents = []`. `fuzzy._get_scoped_candidates` then pulled the entire OTHER_CODE catalog as candidates; `semantic_resolve` fell back to `_TAX_CORE_PARENT_IDS`, i.e. it semantically searched CGI/LPF/CIBS for a Code-du-travail citation. `extract_code_family_from_mention` now returns `(family, parent_text_ids)` mirroring `infer_code_family`, with parents pulled from the same extended alias map already built from `legi_reference_catalog`. |
| `feat(crossref): pipeline_version invalidates source state on inference changes` | B1 | `source_hash` and `catalog_hash` do not capture changes to extractor / resolver / fuzzy / semantic / alias_detector / confidence / pipeline. After a deploy of those modules, documents whose source content was unchanged were silently skipped and the graph kept serving the prior run's results. New `pipeline_version` column on `cross_reference_source_state` (with `IF NOT EXISTS` migration), checked alongside the hashes; `crossreference._version.PIPELINE_VERSION` is bumped on inference changes. |
| `fix(crossref): cleaner reset-catalog + confirmation; align spec sections` | B2 + spec drift | `clean_crossreferences` did not touch `legi_reference_catalog`; the CLI also had no confirmation gate. New `--reset-catalog` flag (only valid with `--source=all`) TRUNCATEs the catalog. `--yes` is required to skip the interactive prompt; non-TTY sessions without `--yes` refuse to run. CROSSREFERENCE.md §10.6, §11, §12.1 and §17 rule 13 now match the implementation. |

## Verification

- `python3 -m pytest tests/crossreference -q` → **50 passed**.
- Manual end-to-end check on the original bug-report mentions and on enumeration:

| matched_text | article_token | normalized_number | norm(matched_text) |
| --- | --- | --- | --- |
| `1745 du code général des impôts` | `1745` | `1745` | `1745` |
| `L. 247 du livre des procédures fiscales` | `L. 247` | `L247` | `L247` |
| `238 du l'annexe II au code général des impôts` | `238` | `238` | `238` |
| `117 du code général des impôts` | `117` | `117` | `117` |
| `L. 53 du livre des procédures fiscales` | `L. 53` | `L53` | `L53` |
| `38` (in enumeration) | `38` | `38` | `38` |
| `39` (in enumeration) | `39` | `39` | `39` |
| `39 A du code général des impôts` (in enumeration) | `39 A` | `39 A` | `39 A` |

Pipeline-side and resolver-side normalization keys now converge for every case.

## Rollout

`refresh_legi_reference_catalog` runs at the start of `infer_crossreferences`. The `pipeline_version` column starts empty for existing rows (`DEFAULT ''`) and the new constant is `2026.04.30-1`, so every existing source doc is forced to rebuild on the first run after deploy. No manual data migration needed.

```bash
python main.py infer_crossreferences --source all
```

Optional explicit reset (now requires confirmation; `--yes` for non-TTY):

```bash
python main.py clean_crossreferences --source all --reset-catalog --yes
python main.py infer_crossreferences --source all
```

Post-run validation SQL:

```sql
-- Every state row now stamped with the current pipeline version.
SELECT pipeline_version, COUNT(*)
FROM cross_reference_source_state
GROUP BY 1;

-- JADE doc with multiple chunks: occurrence_count should now match
-- chunk-local cardinality, not chunk count × actual occurrences.
SELECT source_doc_id, target_legi_doc_id, occurrence_count
FROM cross_reference_legi_edges
WHERE source_type = 'jade'
ORDER BY occurrence_count DESC
LIMIT 10;

-- OTHER_CODE detection now produces parent ids: the resolver should resolve
-- 'L. 1242-1 du code du travail' to a code-du-travail target.
SELECT matched_text, target_parent_text_id, resolver_method, confidence
FROM cross_reference_legi_mentions
WHERE matched_text ILIKE '%code du travail%'
LIMIT 20;
```

## Remaining (deferred)

Minor / nit findings the deep review surfaced but this PR does not touch:

- `_LETTER_PREFIX_GAP_RE` runs as a global `re.sub`; never misfires on real article-token inputs but would on free-form strings ever reaching the normalizer.
- `TRAILING_CODE_CLAUSE_RE` in `_patterns.py` is dead code (the normalizer uses `PREPOSITION_RE.finditer` instead).
- `SEMANTIC_MIN_SCORE` / `SEMANTIC_CODE_ALIASED_MIN` constant names are inversely related to their usage.
- `_extended_alias_cache` first-load is not concurrency-safe.
- `_embedding_column_available` caches `True` for process lifetime.
- `aggregate_and_upsert_edges` `GROUP BY` is wider than the table's PK; in practice the extra columns are functions of the PK so only one group exists per PK, but the invariant is not enforced in code.

None change behaviour for any of the failure modes the bug report flagged. Ready to land in a follow-up if desired.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43e8e6bb-0e4a-4841-8eaa-4b5edb4c31ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43e8e6bb-0e4a-4841-8eaa-4b5edb4c31ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

